### PR TITLE
[geoclue-provider-hybris] Move to standardised .conf keys. Contributes to JB#35159

### DIFF
--- a/hybrisprovider.h
+++ b/hybrisprovider.h
@@ -245,6 +245,7 @@ private:
     qint64 m_ntpRequestTicks;
 
     bool m_agpsEnabled;
+    bool m_agpsOnlineEnabled;
     double m_magneticVariation;
 };
 


### PR DESCRIPTION
This commit ensures that the hybris plugin looks at the keys from the
appropriate subgroup (location/gps) from the location.conf file.

Contributes to JB#35159