### PR TITLE
[geoclue-provider-hybris] Allow setuid() application. Contributes to JB#36127

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -28,6 +28,10 @@ int main(int argc, char *argv[])
     uid_t effectiveUid;
     uid_t savedUid;
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 3, 0)
+    QCoreApplication::setSetuidAllowed(true);
+#endif
+
     int result = getresuid(&realUid, &effectiveUid, &savedUid);
     if (result == -1)
         qFatal("Failed to get process uids, %s", strerror(errno));


### PR DESCRIPTION
From Qt 5.3 onwards, applications which require setuid need to
explicitly declare that.

Contributes to JB#36127