### PR TITLE
[geoclue-provider-hybris] Fix build with Qt 5.6. Contributes to JB#36127

### DIFF
--- a/hybrisprovider.cpp
+++ b/hybrisprovider.cpp
@@ -1068,7 +1068,8 @@ void HybrisProvider::dataServiceConnected()
     if (!m_agpsOnlineEnabled)
         return;
 
-    foreach (NetworkService *service, m_networkManager->getServices(QStringLiteral("cellular"))) {
+    QVector<NetworkService*> services = m_networkManager->getServices(QStringLiteral("cellular"));
+    Q_FOREACH (NetworkService *service, services) {
         if (!service->connected())
             continue;
 


### PR DESCRIPTION
Q_FOREACH in Qt 5.6 was changed.  This commit fixes the build break
which results from the new implementation.

Contributes to JB#36127