### PR TITLE
[geoclue-provider-hybris] Listen to config directory changes. Contributes to JB#36857

### DIFF
--- a/hybrisprovider.cpp
+++ b/hybrisprovider.cpp
@@ -60,6 +60,7 @@ const quint32 PreferredAccuracy = 0;
 const quint32 PreferredInitialFixTime = 0;
 const double KnotsToMps = 0.514444;
 
+const QString LocationSettingsDir = QStringLiteral("/etc/location/");
 const QString LocationSettingsFile = QStringLiteral("/etc/location/location.conf");
 const QString LocationSettingsEnabledKey = QStringLiteral("location/enabled");
 const QString LocationSettingsGpsEnabledKey = QStringLiteral("location/gps/enabled");
@@ -449,6 +450,9 @@ HybrisProvider::HybrisProvider(QObject *parent)
     m_locationSettings = new QFileSystemWatcher(this);
     connect(m_locationSettings, SIGNAL(fileChanged(QString)),
             this, SLOT(locationEnabledChanged()));
+    connect(m_locationSettings, SIGNAL(directoryChanged(QString)),
+            this, SLOT(locationEnabledChanged()));
+    m_locationSettings->addPath(LocationSettingsDir);
     m_locationSettings->addPath(LocationSettingsFile);
 
     new GeoclueAdaptor(this);


### PR DESCRIPTION
When QSettings writes values to the settings file, it can perform
an atomic replacement via delete+rename.  This can result in missed
change signals if the QFileSystemWatcher is not watching the directory
but just the file.

This commit ensures that we listen to config directory changes as
well as config file changes.

Contributes to JB#36857