### PR TITLE
[geoclue-provider-hybris] Enforce MDM policy setting if active. Contributes to JB#37470

### DIFF
--- a/geoclue-providers-hybris.pro
+++ b/geoclue-providers-hybris.pro
@@ -8,7 +8,7 @@ target.path = /usr/libexec
 QT = core dbus network
 
 CONFIG += link_pkgconfig
-PKGCONFIG += libhardware android-headers connman-qt5 qofono-qt5 qofonoext
+PKGCONFIG += libhardware android-headers connman-qt5 qofono-qt5 qofonoext sailfishmdm-policy
 
 LIBS += -lrt
 

--- a/hybrisprovider.h
+++ b/hybrisprovider.h
@@ -41,6 +41,7 @@ QT_FORWARD_DECLARE_CLASS(QHostAddress)
 QT_FORWARD_DECLARE_CLASS(QUdpSocket)
 QT_FORWARD_DECLARE_CLASS(QHostInfo)
 
+namespace Sailfish { namespace Mdm { class HardwareAccessPolicy; } }
 class ComJollaConnectiondInterface;
 class ComJollaLipstickConnectionSelectorIfInterface;
 class MGConfItem;
@@ -173,6 +174,7 @@ private:
     void processConnectionContexts();
     void processNextConnectionContext();
 
+    Sailfish::Mdm::HardwareAccessPolicy *m_mdmPolicy;
     gps_device_t *m_gpsDevice;
 
     const GpsInterface *m_gps;

--- a/rpm/geoclue-providers-hybris.spec
+++ b/rpm/geoclue-providers-hybris.spec
@@ -14,6 +14,7 @@ BuildRequires: pkgconfig(android-headers)
 BuildRequires: pkgconfig(connman-qt5) >= 1.0.68
 BuildRequires: pkgconfig(qofono-qt5)
 BuildRequires: pkgconfig(qofonoext)
+BuildRequires: pkgconfig(sailfishmdm-policy)
 BuildRequires: oneshot
 Requires: connectionagent-qt5 >= 0.9.20
 Requires: oneshot


### PR DESCRIPTION
This commit adds support for global enablement/disablement of the
gps positioning service depending on the MDM policy setting.

Contributes to JB#37470