### PR TITLE
[geoclue-provider-hybris] Use LocationConfiguration for settings access. Contributes to JB#37470

### DIFF
--- a/devicecontrol.h
+++ b/devicecontrol.h
@@ -14,26 +14,32 @@
 #define DEVICECONTROL_H
 
 #include <QtCore/QObject>
+#include <QtCore/QString>
+
+#include <locationsettings.h>
 
 QT_FORWARD_DECLARE_CLASS(QDBusVariant)
+
+/* DeviceControl provides a mechanism which connman can use
+ * to disable the GPS when Flight Mode is activated */
 
 class DeviceControl : public QObject
 {
     Q_OBJECT
-
     Q_PROPERTY(bool Powered READ powered WRITE setPowered NOTIFY poweredChanged)
 
 public:
-    explicit DeviceControl(QObject *parent = 0);
+    explicit DeviceControl(LocationSettings *settings, QObject *parent = 0);
 
     bool powered() const;
-    void setPowered(bool powered);
+    void setPowered(bool newPowered);
 
 signals:
     void PropertyChanged(const QString &name, const QDBusVariant &value);
     void poweredChanged();
 
 private:
+    LocationSettings *m_settings;
     bool m_powered;
 };
 

--- a/geoclue-providers-hybris.pro
+++ b/geoclue-providers-hybris.pro
@@ -8,7 +8,7 @@ target.path = /usr/libexec
 QT = core dbus network
 
 CONFIG += link_pkgconfig
-PKGCONFIG += libhardware android-headers connman-qt5 qofono-qt5 qofonoext
+PKGCONFIG += libhardware android-headers connman-qt5 qofono-qt5 qofonoext systemsettings
 
 LIBS += -lrt
 

--- a/hybrisprovider.h
+++ b/hybrisprovider.h
@@ -23,6 +23,8 @@
 #include <android-version.h>
 #include <hardware/gps.h>
 
+#include <locationsettings.h>
+
 #include "locationtypes.h"
 
 // Define versions of the Android GPS interface supported.
@@ -59,7 +61,7 @@ public:
     explicit HybrisProvider(QObject *parent = 0);
     ~HybrisProvider();
 
-    void setDeviceController(DeviceControl *control);
+    void setLocationSettings(LocationSettings *settings);
 
     // org.freedesktop.Geoclue
     void AddReference();
@@ -211,8 +213,6 @@ private:
 
     Status m_status;
 
-    QFileSystemWatcher *m_locationSettings;
-
     bool m_positionInjectionConnected;
 
     QNetworkAccessManager *m_manager;
@@ -229,7 +229,7 @@ private:
 
     bool m_gpsStarted;
 
-    DeviceControl *m_deviceControl;
+    LocationSettings *m_locationSettings;
 
     NetworkManager *m_networkManager;
     NetworkTechnology *m_cellularTechnology;

--- a/main.cpp
+++ b/main.cpp
@@ -17,6 +17,8 @@
 #include "hybrisprovider.h"
 #include "devicecontrol.h"
 
+#include <locationsettings.h>
+
 #include <unistd.h>
 #include <sys/types.h>
 #include <grp.h>
@@ -70,7 +72,8 @@ int main(int argc, char *argv[])
 
     // Register service on DBus system bus prior to dropping privileges.
     QDBusConnection system = QDBusConnection::systemBus();
-    DeviceControl control;
+    LocationSettings settings;
+    DeviceControl control(&settings);
     if (!system.registerObject(QStringLiteral("/com/jollamobile/gps/Device"), &control))
         qFatal("Failed to register object /com/jollamobile/gps/Device");
     if (!system.registerService(QStringLiteral("com.jollamobile.gps")))
@@ -85,11 +88,11 @@ int main(int argc, char *argv[])
 
     QDBusConnection session = QDBusConnection::sessionBus();
     HybrisProvider provider;
+    provider.setLocationSettings(&settings);
     if (!session.registerObject(QStringLiteral("/org/freedesktop/Geoclue/Providers/Hybris"), &provider))
         qFatal("Failed to register object /org/freedesktop/Geoclue/Providers/Hybris");
     if (!session.registerService(QStringLiteral("org.freedesktop.Geoclue.Providers.Hybris")))
         qFatal("Failed to register service org.freedesktop.Geoclue.Providers.Hybris");
-    provider.setDeviceController(&control);
 
     return a.exec();
 }

--- a/rpm/geoclue-providers-hybris.spec
+++ b/rpm/geoclue-providers-hybris.spec
@@ -14,6 +14,7 @@ BuildRequires: pkgconfig(android-headers)
 BuildRequires: pkgconfig(connman-qt5) >= 1.0.68
 BuildRequires: pkgconfig(qofono-qt5)
 BuildRequires: pkgconfig(qofonoext)
+BuildRequires: pkgconfig(systemsettings)
 BuildRequires: oneshot
 Requires: connectionagent-qt5 >= 0.9.20
 Requires: oneshot


### PR DESCRIPTION
This allows other clients (jolla-settings-system, web browser, csd)
to use a single API (LocationSettings) to read or write the various
location settings, without needing to also interrogate connman's
gps technology model.

Another effect of this is that clients will no longer be able to
bypass the MDM / access policy and toggle gps enablement by using
connman's gps technology model API.