### PR TITLE
[geoclue-provider-hybris] download Xtra data automatically. 

### DIFF
--- a/hybrisprovider.h
+++ b/hybrisprovider.h
@@ -155,6 +155,7 @@ private slots:
     void engineOff();
 
     void technologiesChanged();
+    void stateChanged(const QString &state);
     void defaultDataModemChanged(const QString &modem);
     void connectionManagerValidChanged();
     void connectionContextValidChanged();
@@ -220,6 +221,7 @@ private:
     QNetworkAccessManager *m_manager;
     QNetworkReply *m_xtraDownloadReply;
     QQueue<QUrl> m_xtraServers;
+    int m_xtraServerIndex;
 
     ComJollaConnectiondInterface *m_connectiond;
     ComJollaLipstickConnectionSelectorIfInterface *m_connectionSelector;
@@ -235,6 +237,7 @@ private:
 
     NetworkManager *m_networkManager;
     NetworkTechnology *m_cellularTechnology;
+    NetworkTechnology *m_wifiTechnology;
 
     QOfonoExtModemManager *m_ofonoExtModemManager;
     QOfonoConnectionManager *m_connectionManager;
@@ -248,6 +251,8 @@ private:
 
     bool m_agpsEnabled;
     bool m_agpsOnlineEnabled;
+    bool m_useForcedXtraInject;
+    QString m_xtraUserAgent;
     double m_magneticVariation;
 };
 


### PR DESCRIPTION
    On devices where Xtra data is normally downloaded from within java, this
    can be used as a workaround.
    
    To activate create /etc/gps_xtra.ini with content similar to:
    
    ===============================================================================
    [xtra]
    
    XTRA_FORCE_INJECT = 1
    XTRA_SERVER_1 = place actual url here (see /system/etc/gps.conf)
    XTRA_SERVER_2 = place actual url here (see /system/etc/gps.conf)
    XTRA_SERVER_3 = place actual url here (see /system/etc/gps.conf)
    XTRA_USERAGENT_FILE = /data/misc/location/xtra/useragent.txt
    ===============================================================================
    
    replace the URLs and paths with those as found on your device.
    
    XTRA_SERVER_x will be read from /system/etc/gps.conf if available,
    and to avoid modifying this read-only file the XTRA_SERVER_x can also
    be put into /etc/gps_xtra.ini.