### PR TITLE
Don't fail if /system/etc/gps.conf does not exist. Remove certain groups from the setgroups call to avoid confusing the BSP.

### DIFF
--- a/hybrisprovider.cpp
+++ b/hybrisprovider.cpp
@@ -575,21 +575,21 @@ HybrisProvider::HybrisProvider(QObject *parent)
 
     if (m_xtraServers.isEmpty()) {
         QFile gpsConf(QStringLiteral("/system/etc/gps.conf"));
-        if (!gpsConf.open(QIODevice::ReadOnly))
-            return;
+        if (gpsConf.open(QIODevice::ReadOnly)) {
 
-        while (!gpsConf.atEnd()) {
-            const QByteArray line = gpsConf.readLine().trimmed();
-            if (line.startsWith('#'))
-                continue;
+            while (!gpsConf.atEnd()) {
+                const QByteArray line = gpsConf.readLine().trimmed();
+                if (line.startsWith('#'))
+                    continue;
 
-            const QList<QByteArray> split = line.split('=');
-            if (split.length() != 2)
-                continue;
+                const QList<QByteArray> split = line.split('=');
+                if (split.length() != 2)
+                    continue;
 
-            const QByteArray key = split.at(0).trimmed();
-            if (key == "XTRA_SERVER_1" || key == "XTRA_SERVER_2" || key == "XTRA_SERVER_3")
-                m_xtraServers.enqueue(QUrl::fromEncoded(split.at(1).trimmed()));
+                const QByteArray key = split.at(0).trimmed();
+                if (key == "XTRA_SERVER_1" || key == "XTRA_SERVER_2" || key == "XTRA_SERVER_3")
+                    m_xtraServers.enqueue(QUrl::fromEncoded(split.at(1).trimmed()));
+            }
         }
     }
 

--- a/main.cpp
+++ b/main.cpp
@@ -55,6 +55,21 @@ int main(int argc, char *argv[])
 
     supplementaryGroups[numberGroups++] = group->gr_gid;
 
+    // remove audio, radio and bluetooth groups to avoid confusion in BSP
+    char *groups_to_remove[] = {"bluetooth", "radio", "audio", NULL};
+
+    int idx = 0;
+    while (groups_to_remove[idx]) {
+        group = getgrnam(groups_to_remove[idx]);
+        idx++;
+
+        if (idx + 1 < numberGroups) {
+            memmove((void*)&supplementaryGroups[idx], (void*)&supplementaryGroups[idx + 1], (numberGroups - idx - 1) * sizeof(gid_t));
+        }
+
+        numberGroups--;
+    }
+
 #if GEOCLUE_ANDROID_GPS_INTERFACE >= 2
     group = getgrnam("net_raw");
     if (group) {


### PR DESCRIPTION
* Don't fail if /system/etc/gps.conf doesn't exist.
* remove certain groups from the setgroups call to avoid confusing the BSP (qcom)