### PR TITLE
[geoclue-provider-hybris] Make packages built from different specs conflict. JB#44524

### DIFF
--- a/rpm/geoclue-providers-hybris-binder.spec
+++ b/rpm/geoclue-providers-hybris-binder.spec
@@ -1,3 +1,11 @@
+Name: geoclue-provider-hybris-binder
+Version: 0.2.22
+Release: 1
+Provides: geoclue-provider-hybris = %{version}-%{release}
+Conflicts: geoclue-provider-hybris <= 0.2.21
+Conflicts: geoclue-provider-hybris-hal
+Obsoletes: geoclue-provider-hybris < %{version}-%{release}
+
 # libgbinder is currently not a common package, so we have to rely on tar_git.
 BuildRequires: pkgconfig(libgbinder)
 

--- a/rpm/geoclue-providers-hybris.inc
+++ b/rpm/geoclue-providers-hybris.inc
@@ -1,6 +1,3 @@
-Name: geoclue-provider-hybris
-Version: 0.0.1
-Release: 1
 Summary: Geoinformation Service Hybris Provider
 Group: System/Libraries
 URL: https://bitbucket.org/jolla/base-geoclue-providers-hybris

--- a/rpm/geoclue-providers-hybris.spec
+++ b/rpm/geoclue-providers-hybris.spec
@@ -1,3 +1,11 @@
+Name: geoclue-provider-hybris-hal
+Version: 0.2.22
+Release: 1
+Provides: geoclue-provider-hybris = %{version}-%{release}
+Conflicts: geoclue-provider-hybris <= 0.2.21
+Conflicts: geoclue-provider-hybris-binder
+Obsoletes: geoclue-provider-hybris < %{version}-%{release}
+
 BuildRequires: pkgconfig(libhardware)
 BuildRequires: pkgconfig(android-headers)
 


### PR DESCRIPTION
This assumes that if both binder and hal packages are available binder package will be preferred.