### PR TITLE
Fix setting accuracy

### DIFF
--- a/hybrisprovider.cpp
+++ b/hybrisprovider.cpp
@@ -520,10 +520,6 @@ void HybrisProvider::setLocation(const Location &location)
     }
 
     m_currentLocation = location;
-    Accuracy acc;
-    acc.setHorizontal(location.accuracy().horizontal());
-    acc.setVertical(location.accuracy().vertical());
-    m_currentLocation.setAccuracy(acc);
 
     if (m_currentLocation.timestamp() != 0 && m_currentLocation.timestamp() < GnssWeekRolloverTimestamp) {
         qCDebug(lcGeoclueHybris) << "Fixing timestamp offset";

--- a/hybrisprovider.cpp
+++ b/hybrisprovider.cpp
@@ -520,6 +520,10 @@ void HybrisProvider::setLocation(const Location &location)
     }
 
     m_currentLocation = location;
+    Accuracy acc;
+    acc.setHorizontal(location.accuracy().horizontal());
+    acc.setVertical(location.accuracy().vertical());
+    m_currentLocation.setAccuracy(acc);
 
     if (m_currentLocation.timestamp() != 0 && m_currentLocation.timestamp() < GnssWeekRolloverTimestamp) {
         qCDebug(lcGeoclueHybris) << "Fixing timestamp offset";

--- a/locationtypes.h
+++ b/locationtypes.h
@@ -55,7 +55,7 @@ public:
     LocationData(const LocationData &other)
     :   QSharedData(other), timestamp(other.timestamp), latitude(other.latitude),
         longitude(other.longitude), altitude(other.altitude), speed(other.speed),
-        direction(other.direction), climb(other.climb)
+        direction(other.direction), climb(other.climb), accuracy(other.accuracy)
     { }
     ~LocationData() { }
 


### PR DESCRIPTION
So, for some reason, after `m_currentLocation = location;` accuracy becones NaN. I tried doing `m_currentLocation.setAccuracy(location.accuracy())` but the accuracy was still NaN. I tried `m_currentLocation.accuracy().setHorizontal(location.accuracy().horizontal());` but that was NaN as well. This solution thankfully works. If you want to debug it further and find real reason, feel free, I would just like to have working accuracy asap