### PR TITLE
hal: Handle not being able to set the SUPL server.

### DIFF
--- a/hal/hallocationbackend.cpp
+++ b/hal/hallocationbackend.cpp
@@ -681,7 +681,10 @@ bool HalLocationBackend::aGnssDataConnOpen(const QByteArray &apn, const QString 
 
 int HalLocationBackend::aGnssSetServer(HybrisAGnssType type, const char* hostname, int port)
 {
-    return m_agps->set_server(type, hostname, port);
+    if (m_agps) {
+        return m_agps->set_server(type, hostname, port);
+    }
+    return 0;
 }
 
 // AGnssRil


### PR DESCRIPTION
https://github.com/mer-hybris/geoclue-providers-hybris/commit/e982cf94047993e5868d44307f4a38f1b89500ea added support for overriding/setting the SUPL server. This could however lead to a crash when AGPS isn't actually available. Handle this by returning an error instead of crashing.

Signed-off-by: Darrel Griët <dgriet@gmail.com>