### PR TITLE
geoclue-providers-hybris: Provide initialization for Fused Location Provider.

### DIFF
--- a/binder/binderlocationbackend.cpp
+++ b/binder/binderlocationbackend.cpp
@@ -1215,3 +1215,8 @@ void BinderLocationBackend::aGnssRilInit()
     }
     gbinder_remote_reply_unref(reply);
 }
+
+// AFlp
+bool BinderLocationBackend::aFlpInit()
+{
+}

--- a/binder/binderlocationbackend.h
+++ b/binder/binderlocationbackend.h
@@ -71,6 +71,9 @@ public:
     // AGnssRil
     void aGnssRilInit();
 
+    // AFlp
+    bool aFlpInit();
+
 private:
     bool isReplySuccess(GBinderRemoteReply *reply);
     GBinderRemoteObject *getExtensionObject(GBinderRemoteReply *reply);

--- a/hal/hallocationbackend.h
+++ b/hal/hallocationbackend.h
@@ -24,6 +24,7 @@
 
 #include <android-version.h>
 #include <hardware/gps.h>
+#include <hardware/fused_location.h>
 
 #include <locationsettings.h>
 
@@ -69,8 +70,12 @@ public:
     // AGnssRil
     void aGnssRilInit();
 
+    // AFlp
+    bool aFlpInit();
+
 private:
     gps_device_t *m_gpsDevice;
+    flp_device_t *m_flpDevice;
 
     const GpsInterface *m_gps;
 
@@ -80,6 +85,8 @@ private:
     const GpsXtraInterface *m_xtra;
 
     const GpsDebugInterface *m_debug;
+
+    const FlpLocationInterface *m_flp;
 };
 
 #endif // HALLOCATIONBACKEND_H

--- a/hybrislocationbackend.h
+++ b/hybrislocationbackend.h
@@ -141,6 +141,9 @@ public:
     // AGnssRil
     virtual void aGnssRilInit() = 0;
 
+    // aFlpInit
+    virtual bool aFlpInit() = 0;
+
 };
 
 HybrisLocationBackend *getLocationBackend();

--- a/hybrisprovider.cpp
+++ b/hybrisprovider.cpp
@@ -256,6 +256,7 @@ HybrisProvider::HybrisProvider(QObject *parent)
     m_backend->aGnssRilInit();
     m_backend->gnssXtraInit();
     m_backend->gnssDebugInit();
+    m_backend->aFlpInit();
 
     // Set SUPL server if provided
     if (!m_suplHost.isEmpty() && m_suplPort > 0) {


### PR DESCRIPTION
This provides the basic needs to initialize the Fused Location Provider. It's based on the hardware header provided by Google[^1]. The Fused Location Provider is only loaded whenever the hardware module (`flp.*.so`) exists.

[^1]: https://android.googlesource.com/platform/hardware/libhardware/+/refs/tags/android-8.0.0_r51/include/hardware/fused_location.h