### PR TITLE
[geoclue-providers-hybris] Remove obsolete/ignored systemd property. JB#61600

### DIFF
--- a/geoclue-providers-hybris.service
+++ b/geoclue-providers-hybris.service
@@ -6,7 +6,6 @@ Type=dbus
 ExecStart=/usr/libexec/geoclue-hybris
 BusName=org.freedesktop.Geoclue.Providers.Hybris
 #Sandboxing
-Capabilities=
 PrivateTmp=yes
 ProtectHome=yes
 ProtectSystem=full


### PR DESCRIPTION
"/usr/lib/systemd/user/geoclue-providers-hybris.service:9: Support for option Capabilities= has been removed and it is ignored"

Removed 2016, systemd v230.