### PR TITLE
Add env variable to disable AIDL

### DIFF
--- a/binder/binderlocationbackend_aidl.cpp
+++ b/binder/binderlocationbackend_aidl.cpp
@@ -488,6 +488,10 @@ BinderLocationBackendAidl::BinderLocationBackendAidl(QObject *parent)
 bool BinderLocationBackendAidl::isSupported()
 {
     bool ret = false;
+    if (qgetenv("GEOCLUE_HYBRIS_DISABLE_AIDL") == "1"){
+        return false;
+    }
+
     GBinderServiceManager *sm =
         gbinder_servicemanager_new(GNSS_BINDER_DEFAULT_DEV);
 


### PR DESCRIPTION
At least one device (volla quintus) exposes both an AIDL and HIDL interface, but the AIDL interface does not work.  Location stopped working when AIDL support was added.